### PR TITLE
Fix elo rating calculation

### DIFF
--- a/api/services/match.js
+++ b/api/services/match.js
@@ -5,7 +5,7 @@ var Match = require('../model/match-model');
 var all = () => {
   var deferred = Q.defer();
   Match.find({})
-  .sort({date: 'desc'})
+  .sort({date: 'asc'})
   .exec((err, results) => {
     if (err) {
       deferred.reject(err);


### PR DESCRIPTION
Elo rating calculation was flawed since matches was ordered from new to old instead of old to new.
